### PR TITLE
API 호출이 가능하도록 인증 설정 변경하기

### DIFF
--- a/src/main/java/com/min/projectboard/config/DataRestConfig.java
+++ b/src/main/java/com/min/projectboard/config/DataRestConfig.java
@@ -1,5 +1,8 @@
 package com.min.projectboard.config;
 
+import com.min.projectboard.domain.Article;
+import com.min.projectboard.domain.ArticleComment;
+import com.min.projectboard.domain.Hashtag;
 import com.min.projectboard.domain.UserAccount;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -11,7 +14,11 @@ public class DataRestConfig {
     @Bean
     public RepositoryRestConfigurer repositoryRestConfigurer() {
         return RepositoryRestConfigurer.withConfig((config, cors) ->
-                config.exposeIdsFor(UserAccount.class)
+                config
+                        .exposeIdsFor(UserAccount.class)
+                        .exposeIdsFor(Article.class)
+                        .exposeIdsFor(ArticleComment.class)
+                        .exposeIdsFor(Hashtag.class)
         );
     }
 

--- a/src/main/java/com/min/projectboard/config/SecurityConfig.java
+++ b/src/main/java/com/min/projectboard/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
         return http
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll()
+                        .mvcMatchers("/api/**").permitAll()
                         .mvcMatchers(
                                 HttpMethod.GET,
                                 "/",
@@ -46,6 +47,7 @@ public class SecurityConfig {
                 .oauth2Login(oAuth -> oAuth
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(oAuth2UserService)))
+                .csrf(csrf -> csrf.ignoringAntMatchers("/api/**"))
                 .build();
     }
 

--- a/src/main/java/com/min/projectboard/domain/projection/ArticleCommentProjection.java
+++ b/src/main/java/com/min/projectboard/domain/projection/ArticleCommentProjection.java
@@ -1,0 +1,19 @@
+package com.min.projectboard.domain.projection;
+
+import com.min.projectboard.domain.ArticleComment;
+import com.min.projectboard.domain.UserAccount;
+import org.springframework.data.rest.core.config.Projection;
+
+import java.time.LocalDateTime;
+
+@Projection(name = "withUserAccount", types = ArticleComment.class)
+public interface ArticleCommentProjection {
+    Long getId();
+    UserAccount getUserAccount();
+    Long getParentCommentId();
+    String getContent();
+    LocalDateTime getCreatedAt();
+    String getCreatedBy();
+    LocalDateTime getModifiedAt();
+    String getModifiedBy();
+}

--- a/src/main/java/com/min/projectboard/domain/projection/ArticleProjection.java
+++ b/src/main/java/com/min/projectboard/domain/projection/ArticleProjection.java
@@ -1,0 +1,19 @@
+package com.min.projectboard.domain.projection;
+
+import com.min.projectboard.domain.Article;
+import com.min.projectboard.domain.UserAccount;
+import org.springframework.data.rest.core.config.Projection;
+
+import java.time.LocalDateTime;
+
+@Projection(name = "withUserAccount", types = Article.class)
+public interface ArticleProjection {
+    Long getId();
+    UserAccount getUserAccount();
+    String getTitle();
+    String getContent();
+    LocalDateTime getCreatedAt();
+    String getCreatedBy();
+    LocalDateTime getModifiedAt();
+    String getModifiedBy();
+}

--- a/src/main/java/com/min/projectboard/domain/projection/UserAccountProjection.java
+++ b/src/main/java/com/min/projectboard/domain/projection/UserAccountProjection.java
@@ -1,0 +1,18 @@
+package com.min.projectboard.domain.projection;
+
+import com.min.projectboard.domain.UserAccount;
+import org.springframework.data.rest.core.config.Projection;
+
+import java.time.LocalDateTime;
+
+@Projection(name = "withoutPassword", types = UserAccount.class)
+public interface UserAccountProjection {
+    String getUserId();
+    String getEmail();
+    String getNickname();
+    String getMemo();
+    LocalDateTime getCreatedAt();
+    String getCreatedBy();
+    LocalDateTime getModifiedAt();
+    String getModifiedBy();
+}

--- a/src/main/java/com/min/projectboard/repository/ArticleCommentRepository.java
+++ b/src/main/java/com/min/projectboard/repository/ArticleCommentRepository.java
@@ -4,6 +4,7 @@ import com.min.projectboard.domain.Article;
 import com.min.projectboard.domain.ArticleComment;
 import com.min.projectboard.domain.QArticle;
 import com.min.projectboard.domain.QArticleComment;
+import com.min.projectboard.domain.projection.ArticleCommentProjection;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,7 +15,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
 import java.util.List;
 
-@RepositoryRestResource
+@RepositoryRestResource(excerptProjection = ArticleCommentProjection.class)
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long>,
         QuerydslPredicateExecutor<ArticleComment>,
         QuerydslBinderCustomizer<QArticleComment> {

--- a/src/main/java/com/min/projectboard/repository/ArticleRepository.java
+++ b/src/main/java/com/min/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.min.projectboard.repository;
 
 import com.min.projectboard.domain.Article;
 import com.min.projectboard.domain.QArticle;
+import com.min.projectboard.domain.projection.ArticleProjection;
 import com.min.projectboard.repository.querydsl.ArticleRepositoryCustom;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
@@ -13,7 +14,7 @@ import org.springframework.data.querydsl.binding.QuerydslBinderCustomizer;
 import org.springframework.data.querydsl.binding.QuerydslBindings;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
-@RepositoryRestResource
+@RepositoryRestResource(excerptProjection = ArticleProjection.class)
 public interface ArticleRepository extends JpaRepository<Article, Long>,
         ArticleRepositoryCustom,
         QuerydslPredicateExecutor<Article>,

--- a/src/main/java/com/min/projectboard/repository/UserAccountRepository.java
+++ b/src/main/java/com/min/projectboard/repository/UserAccountRepository.java
@@ -1,7 +1,10 @@
 package com.min.projectboard.repository;
 
 import com.min.projectboard.domain.UserAccount;
+import com.min.projectboard.domain.projection.UserAccountProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource(excerptProjection = UserAccountProjection.class)
 public interface UserAccountRepository extends JpaRepository<UserAccount, String> {
 }


### PR DESCRIPTION
이 pr은 외부 서비스에서 원활하게 게시판 서비스의 데이터 api를 이용할 수 있도록 시큐리티 
설정을 업데이트 한다.